### PR TITLE
rustdoc changes (source links and feature labels)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ reqwest-streams = { version = "0.5", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 tokio = { version = "1.35", features = ["full"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod v1;

--- a/src/v1/gemini.rs
+++ b/src/v1/gemini.rs
@@ -78,6 +78,7 @@ pub enum Model {
     #[default]
     GeminiPro,
     #[cfg(feature = "beta")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
     Gemini1_5Pro,
     GeminiProVision,
     // TODO Embedding001
@@ -210,6 +211,7 @@ pub mod request {
         pub generation_config: Option<GenerationConfig>,
 
         #[cfg(feature = "beta")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(default, rename = "system_instruction")]
         pub system_instruction: Option<SystemInstructionContent>,
@@ -232,6 +234,7 @@ pub mod request {
         }
 
         #[cfg(feature = "beta")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
         pub fn set_system_instruction(&mut self, instruction: SystemInstructionContent) {
             self.system_instruction = Some(instruction);
         }
@@ -314,10 +317,12 @@ pub mod request {
         pub stop_sequences: Option<Vec<String>>,
 
         #[cfg(feature = "beta")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
         pub response_mime_type: Option<String>,
     }
 
     #[cfg(feature = "beta")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
     #[derive(Debug, Clone, Deserialize, Serialize)]
     pub struct SystemInstructionContent {
         #[serde(default)]
@@ -325,6 +330,7 @@ pub mod request {
     }
 
     #[cfg(feature = "beta")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
     #[derive(Debug, Clone, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct SystemInstructionPart {


### PR DESCRIPTION
There are two proposed changes in this pull request:
- Make the docs generated on docs.rs use `--generate-link-to-definitions`, so the source is a little more convenient to brows on docs.rs.  (See example [here](https://docs.rs/ump-ng-server/0.3.0/src/ump_ng_server/lib.rs.html#54-74))
- Enable all features when generating docs on docs.rs and instead use feature labels in order to mark what features are required for individual items.

To generate docs with feature labels locally use:
```
$ RUSTFLAGS="--cfg docsrs" RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```

(`cargo doc` still works as usual).